### PR TITLE
Add Worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ wp-content/blogs.dir/
 wp-content/advanced-cache.php
 wp-content/wp-cache-config.php
 
+# Git worktrees
+Worktrees/
+
 # Sensitive data
 *.pem
 *.key


### PR DESCRIPTION
Fixes #4

Adds the Worktrees directory to .gitignore to prevent Git worktree directories from being tracked in the repository.