### PR TITLE
[Issue #11] Add Worktrees to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ wp-content/blogs.dir/
 wp-content/advanced-cache.php
 wp-content/wp-cache-config.php
 
+# Git Worktrees - parallel development directories
+Worktrees/
+
 # Sensitive data
 *.pem
 *.key


### PR DESCRIPTION
Fixes #11

Adds the  directory to  to exclude Git worktrees used for parallel Claude Code sessions.

## Changes
- Added  exclusion to  with descriptive comment

## Context
The worktree guide documents using this directory for parallel development sessions, but it wasn't being ignored by Git.