### PR TITLE
[Issue #12] Generalize design-tokens-example.json

### DIFF
--- a/design-tokens-example.json
+++ b/design-tokens-example.json
@@ -1,8 +1,8 @@
 {
   "meta": {
-    "site": "Forr\u00f3 Federation",
+    "site": "Your Site Name",
     "theme": "Enfold",
-    "export_date": "2025-12-31",
+    "export_date": "YYYY-MM-DD",
     "total_settings": 447
   },
   "colors": {
@@ -76,9 +76,9 @@
     ]
   },
   "assets": {
-    "logo": "https://staging.example.com/wp-content/uploads/2024/05/Untitled-300-x-300-px-100-x-100-px-500-x-100-px-1-300x86.png",
-    "favicon": "https://staging.example.com/wp-content/uploads/2024/05/Untitled-300-x-300-px-100-x-100-px.png",
-    "preloader_logo": "https://staging.example.com/wp-content/uploads/2024/05/Untitled-300-x-300-px-100-x-100-px-500-x-100-px-250-x-71-px.png"
+    "logo": "https://example.com/wp-content/uploads/logo.png",
+    "favicon": "https://example.com/wp-content/uploads/favicon.png",
+    "preloader_logo": "https://example.com/wp-content/uploads/preloader-logo.png"
   },
   "features": {
     "page_preloading": true,


### PR DESCRIPTION
Replaced site-specific content in design-tokens-example.json with generic placeholder values suitable for a reusable plugin template.

## Changes
- Changed site name from 'Forró Federation' to 'Your Site Name'
- Updated export_date from specific date to 'YYYY-MM-DD' placeholder
- Replaced staging.example.com URLs with generic example.com URLs
- Simplified asset filenames to generic placeholders

## Verification
✅ No 'forr' references remain in the file
✅ All site-specific content replaced with appropriate placeholders

Resolves #12