### PR TITLE
[Issue #14] Fix plugin.json shell artifact

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -45,4 +45,3 @@
     ]
   }
 }
-EOF < /dev/null


### PR DESCRIPTION
Fixes #14

Removed the invalid shell heredoc artifact `EOF < /dev/null` from the end of plugin.json that was making the JSON invalid.

## Changes
- Removed `EOF < /dev/null` line from plugin.json
- Verified JSON is now valid

## Testing
- [x] JSON validation passes: `cat plugin.json | python3 -m json.tool`