### PR TITLE
[Issue #23] Add configuration schema to plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -25,6 +25,43 @@
     "wp-status": "commands/wp-status.md",
     "wp-theme": "commands/wp-theme.md"
   },
+  "configuration": {
+    "file": ".claude-wp.json",
+    "schema": {
+      "wordpress_url": {
+        "type": "string",
+        "description": "Production WordPress URL",
+        "required": true
+      },
+      "staging_url": {
+        "type": "string",
+        "description": "Staging WordPress URL",
+        "required": false
+      },
+      "theme": {
+        "type": "string",
+        "enum": ["enfold"],
+        "default": "enfold",
+        "description": "WordPress theme (currently only Enfold supported)"
+      },
+      "content_types": {
+        "type": "array",
+        "items": ["pages", "posts", "portfolio", "layouts"],
+        "default": ["pages"],
+        "description": "Content types to manage via GitOps"
+      },
+      "default_branch": {
+        "type": "string",
+        "default": "main",
+        "description": "Branch that deploys to production"
+      },
+      "staging_branch": {
+        "type": "string",
+        "default": "staging",
+        "description": "Branch that deploys to staging"
+      }
+    }
+  },
   "context": [
     "context/workflow-rules.md",
     "context/worktree-guide.md",


### PR DESCRIPTION
## Summary
- Add configuration schema block to plugin.json that defines the expected structure of .claude-wp.json
- Includes schema for wordpress_url (required), staging_url (optional), theme, content_types, and branch settings
- Provides formal schema for Claude Code sessions to understand available configuration options

## Test plan
- [x] Validate JSON syntax with python3 -m json.tool
- [x] Verify configuration schema exists with jq '.configuration.schema'
- [x] Confirm all required fields are properly defined

Resolves #23

🤖 Generated with [Claude Code](https://claude.ai/code)