### PR TITLE
[Issue #28] Fix JSON Schema compliance in plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -28,38 +28,43 @@
   "configuration": {
     "file": ".claude-wp.json",
     "schema": {
-      "wordpress_url": {
-        "type": "string",
-        "description": "Production WordPress URL",
-        "required": true
+      "type": "object",
+      "properties": {
+        "wordpress_url": {
+          "type": "string",
+          "description": "Production WordPress URL"
+        },
+        "staging_url": {
+          "type": "string",
+          "description": "Staging WordPress URL"
+        },
+        "theme": {
+          "type": "string",
+          "enum": ["enfold"],
+          "default": "enfold",
+          "description": "WordPress theme (currently only Enfold supported)"
+        },
+        "content_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["pages", "posts", "portfolio", "layouts"]
+          },
+          "default": ["pages"],
+          "description": "Content types to manage via GitOps"
+        },
+        "default_branch": {
+          "type": "string",
+          "default": "main",
+          "description": "Branch that deploys to production"
+        },
+        "staging_branch": {
+          "type": "string",
+          "default": "staging",
+          "description": "Branch that deploys to staging"
+        }
       },
-      "staging_url": {
-        "type": "string",
-        "description": "Staging WordPress URL",
-        "required": false
-      },
-      "theme": {
-        "type": "string",
-        "enum": ["enfold"],
-        "default": "enfold",
-        "description": "WordPress theme (currently only Enfold supported)"
-      },
-      "content_types": {
-        "type": "array",
-        "items": ["pages", "posts", "portfolio", "layouts"],
-        "default": ["pages"],
-        "description": "Content types to manage via GitOps"
-      },
-      "default_branch": {
-        "type": "string",
-        "default": "main",
-        "description": "Branch that deploys to production"
-      },
-      "staging_branch": {
-        "type": "string",
-        "default": "staging",
-        "description": "Branch that deploys to staging"
-      }
+      "required": ["wordpress_url"]
     }
   },
   "context": [


### PR DESCRIPTION
## Summary

Fixed JSON Schema compliance issues in plugin.json:
- Added `"type": "object"` at schema root
- Wrapped all properties under `"properties": { ... }`
- Moved `required: true` to top-level `"required": ["wordpress_url"]` array
- Fixed `content_types.items` to be proper schema object `{ "type": "string", "enum": [...] }`

## Changes Made

- Removed invalid `"required": true` from individual property definitions
- Added proper JSON Schema structure with type and properties wrapper
- Fixed array items definition to use proper schema syntax

## Testing

- [x] Schema follows JSON Schema Draft 7 specification
- [x] Required fields properly defined at schema level
- [x] Array items use proper object syntax instead of direct enum array

Resolves #28