### PR TITLE
[Issue #32] Add automated code review handling section to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,45 @@ Commit types: `feat`, `fix`, `chore`, `docs`, `refactor`
 ### 6. Report Back
 Provide the PR URL when complete.
 
+## Handling Automated Code Reviews
+
+PRs may receive automated reviews from Gemini Code Assist or other tools. **Address all comments before merging.**
+
+### Check for Reviews
+```bash
+# View PR with review summary
+gh pr view <number>
+
+# Get review comments
+gh api repos/tuvens/enfold-llm/pulls/<number>/comments --jq '.[].body'
+
+# Get review summaries
+gh api repos/tuvens/enfold-llm/pulls/<number>/reviews --jq '.[] | "\(.user.login): \(.state)"'
+```
+
+### Response Options
+
+| Action | When to Use |
+|--------|-------------|
+| **Implement** | Valid issue - fix before merging |
+| **Defer** | Valid but out of scope - create follow-up issue |
+| **Decline** | Incorrect or N/A - explain reasoning |
+
+### Before Merging
+
+1. Run review check commands above
+2. For each comment: implement, defer (with issue #), or decline (with reason)
+3. Add PR comment documenting decisions:
+   ```
+   Gemini review addressed:
+   - ✅ Fixed [issue]
+   - 📋 Deferred [issue] to #XX
+   - ❌ Declined [suggestion] because [reason]
+   ```
+4. Then merge
+
+**Never merge a PR with unaddressed review comments.**
+
 ## How It Works
 
 ```


### PR DESCRIPTION
## Summary
- Adds comprehensive guidance for handling automated code reviews before merging PRs
- Provides GitHub CLI commands to check for review comments and summaries  
- Documents three response options: implement, defer (create issue), or decline (with reason)
- Requires PR comment documenting all review decisions before merging
- Prevents follow-up issues from unaddressed automated review feedback

## Changes Made
Added "Handling Automated Code Reviews" section to CLAUDE.md with:
1. Commands to check for reviews and comments
2. Response decision matrix table
3. Required documentation process before merging
4. Clear rule: "Never merge a PR with unaddressed review comments"

## Test Plan
- [x] Verify section appears in CLAUDE.md after "Working on GitHub Issues"
- [x] Confirm all commands use correct repository path (tuvens/enfold-llm)
- [x] Test grep command can find the new section

Closes #32

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>